### PR TITLE
#5294 - Removing support for Postgres < 9.0

### DIFF
--- a/bin/cmd_standby
+++ b/bin/cmd_standby
@@ -129,6 +129,8 @@ class CMDStandby(CMDWorker):
 
     # Let's make sure executables can be reached
     def check_config_func(self, options):
+        if int(self.pgversion[0]) < 9:
+            raise Exception('CONFIG: PITRTools only supports PostgreSQL versions 9.0+')
         pathvars = [self.rsync, self.pg_ctl, self.pg_conf, self.pg_hba_conf, self.archivedir]
         if not self.use_streaming_replication:
             pathvars.append(self.pg_standby)
@@ -155,7 +157,6 @@ class CMDStandby(CMDWorker):
                     if not os.access(f, os.F_OK | os.R_OK):
                         raise Exception("CONFIG: unable to read the failover file %s", str(f))
 
-    #
     # Create pg_xlog dir if missing, follow symlink if present
     # XXX: change os.stat to os.access
     def check_pgxlog_path_func(self):
@@ -191,11 +192,7 @@ class CMDStandby(CMDWorker):
         self.pg_standby_flags = '-s5 -w0 -c '
         if self.debug:
             self.pg_standby_flags += '-d '
-
-        if self.pgversion == '8.2':
-            self.pg_standby_args = "%%f %%p -k%s " % (self.numarchives)
-        else:
-            self.pg_standby_args = "%f %p %r "
+        self.pg_standby_args = "%f %p %r "
 
     def set_connect_and_copy_options(self, options):
         # Yes the odd counted " is needed because of the way we have to quote within the command

--- a/doc/cmd_archiver.README
+++ b/doc/cmd_archiver.README
@@ -139,7 +139,7 @@ cmd_archiver.ini options:
 	offline. However, this can cause you to accidently fill up your postgres
 	partition, so use with care.
 
- pgdata: /var/lib/postgresql/8.4/main
+ pgdata: /var/lib/postgresql/9.0/main
 
 	The base database directory. This is the PGDATA on the archiving machine.
 

--- a/doc/cmd_standby.README
+++ b/doc/cmd_standby.README
@@ -10,7 +10,7 @@
 
  * Easily take a base backup, including table spaces
  * Restore archives
- * Automatically purge old archives (if PostgreSQL >8.3)
+ * Automatically purge old archives
  * Alert based on failures
  * Stop and start PostgreSQL standby
  * Failover to the latest restore point and point-in-time recovery
@@ -79,7 +79,7 @@ Configuration:
 
  pgversion: 9.0
 
-	What version of PostgreSQL are we running?
+	What version of PostgreSQL are we running? NOTE: Versions below 9.0 are not compatible.
 
  use_streaming_replication: off
 
@@ -153,7 +153,7 @@ Configuration:
 
 	This is where cmd_archiver is copying files from the master to the standby.
 
- pgdata: /var/lib/postgresql/8.4/main
+ pgdata: /var/lib/postgresql/9.0/main
 
 	The absolute path to your cluster directory.
 
@@ -181,7 +181,7 @@ Configuration:
 	to on to make postgres actually use the above conf files without
 	copying them to pgdata.
 
- recovery_conf: /var/lib/postgresql/8.4/main/recovery.conf
+ recovery_conf: /var/lib/postgresql/9.0/main/recovery.conf
 
 	The absolute path to the recovery.conf to create when we failover.
 	This defaults to %(pgdata)/recovery.conf

--- a/etc/cmd_standby.ini.sample
+++ b/etc/cmd_standby.ini.sample
@@ -1,16 +1,11 @@
 [DEFAULT]
 
 ; what major version are we using?
-pgversion: 8.4
-
-; Used for PostgreSQL version 8.2 and below, should be set 
-; to something > than checkpoint_segments on master
-numarchives: 10
+pgversion: 9.0
 
 ; Whether or not to use streaming replication.  If this is set to "on"
 ; pitrtools will configure the standby server to replicate from master
 ; using streaming replication.
-; This can only be used with PostgreSQL 9.0 and up.
 use_streaming_replication: off
 
 ; File to touch to end replication when using streaming replication.
@@ -58,7 +53,7 @@ ssh_timeout: 30
 archivedir: /var/lib/postgresql/archive
 
 ; where you executed initdb -D to
-pgdata: /var/lib/postgresql/8.4/main
+pgdata: /var/lib/postgresql/9.0/main
 
 
 


### PR DESCRIPTION
- Updates configs and docs for 9.0
- Removes old code for 8.2
- Added check in cmd_standby to cause exit if pgversion < 9.0
